### PR TITLE
Display missing values as unknown

### DIFF
--- a/custom_components/weatherlink/config_flow.py
+++ b/custom_components/weatherlink/config_flow.py
@@ -10,6 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers import selector
 
 from .const import DOMAIN
 from .pyweatherlink import WLHub
@@ -19,7 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 # TODO adjust the data schema to the data that you need
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
-        vol.Required("username"): str,
+        vol.Required("username"): selector.TextSelector(),
         vol.Required("password"): str,
         vol.Required("apitoken"): str,
     }

--- a/custom_components/weatherlink/sensor.py
+++ b/custom_components/weatherlink/sensor.py
@@ -155,12 +155,21 @@ class WLSensor(CoordinatorEntity, SensorEntity):
     def native_value(self):
         """Return the state of the sensor."""
         if self.entity_description.subtag is not None:
+            if (
+                self.coordinator.data[self.entity_description.subtag].get(
+                    self.entity_description.tag
+                )
+                is None
+            ):
+                return None
             value = float(
                 self.coordinator.data[self.entity_description.subtag][
                     self.entity_description.tag
                 ]
             )
         else:
+            if self.coordinator.data.get(self.entity_description.tag) is None:
+                return None
             value = float(self.coordinator.data[self.entity_description.tag])
 
         if self.entity_description.convert is not None:


### PR DESCRIPTION
A sensor value that is temporarily unavaliable eg due to an empty battery in the outdoor unit is now displayed as unknown.
Fixes #8 