### PR TITLE
Adapt to Home Assistant 2023.2 and later

### DIFF
--- a/custom_components/weatherlink/__init__.py
+++ b/custom_components/weatherlink/__init__.py
@@ -37,15 +37,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await coordinator.async_config_entry_first_refresh()
     _LOGGER.debug("First data: %s", coordinator.data)
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok

--- a/custom_components/weatherlink/sensor.py
+++ b/custom_components/weatherlink/sensor.py
@@ -108,7 +108,7 @@ SENSOR_TYPES: Final[tuple[WLSensorDescription, ...]] = (
         device_class=SensorDeviceClass.PRECIPITATION,
         native_unit_of_measurement=UnitOfPrecipitationDepth.MILLIMETERS,
         convert=lambda x: x * 25.4,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     WLSensorDescription(
         key="RainRate",
@@ -128,7 +128,7 @@ SENSOR_TYPES: Final[tuple[WLSensorDescription, ...]] = (
         device_class=SensorDeviceClass.PRECIPITATION,
         native_unit_of_measurement=UnitOfPrecipitationDepth.MILLIMETERS,
         convert=lambda x: x * 25.4,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     WLSensorDescription(
         key="RainInYear",


### PR DESCRIPTION
- Remove call to deprecated routine during setup
- Set correct state_class on precipitation sensors