### PR TITLE
Change negative gust values to 0.0

### DIFF
--- a/custom_components/weatherlink/const.py
+++ b/custom_components/weatherlink/const.py
@@ -3,7 +3,7 @@
 from enum import StrEnum
 
 DOMAIN = "weatherlink"
-VERSION = "2024.4.0b0"
+VERSION = "2024.10.0b0"
 
 MANUFACTURER = "Davis Instruments"
 CONFIG_URL = "https://www.weatherlink.com/"

--- a/custom_components/weatherlink/manifest.json
+++ b/custom_components/weatherlink/manifest.json
@@ -13,6 +13,6 @@
   "issue_tracker": "https://github.com/astrandb/weatherlink/issues",
   "requirements": [],
   "ssdp": [],
-  "version": "2024.4.0b0",
+  "version": "2024.10.0b0",
   "zeroconf": []
 }

--- a/custom_components/weatherlink/sensor.py
+++ b/custom_components/weatherlink/sensor.py
@@ -784,7 +784,22 @@ class WLSensor(CoordinatorEntity, SensorEntity):
     def native_value(self):
         """Return the state of the sensor."""
         # _LOGGER.debug("Key: %s", self.entity_description.key)
-        if self.entity_description.key not in ["WindDir", "BarTrend"]:
+        if self.entity_description.key not in ["WindDir", "BarTrend", "WindGust"]:
+            return self.coordinator.data[self.tx_id].get(self.entity_description.tag)
+
+        if self.entity_description.tag in [DataKey.WIND_GUST_MPH]:
+            if (
+                self.coordinator.data[self.tx_id].get(self.entity_description.tag)
+                is None
+            ):
+                return None
+            if (
+                float(
+                    self.coordinator.data[self.tx_id].get(self.entity_description.tag)
+                )
+                < 0
+            ):
+                return 0.0
             return self.coordinator.data[self.tx_id].get(self.entity_description.tag)
 
         if self.entity_description.tag in [DataKey.WIND_DIR]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpver]
-current_version = 2024.4.0b0
+current_version = 2024.10.0b0
 version_pattern = YYYY.MM.PATCH[PYTAGNUM]
 commit_message = "Bump version from {old_version} to {new_version}"
 commit = False


### PR DESCRIPTION
Due to a "bug" in cloud service a gust value is sometimes reported as -1 mph when it should instead be null = unavailable.
This PR will set negative gust values to 0.0